### PR TITLE
Quiz generation improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@fal-ai/client": "^1.6.1",
         "@supabase/supabase-js": "^2.53.0",
+        "array-shuffle": "^3.0.0",
         "axios": "^1.11.0",
         "cookie-parser": "~1.4.4",
         "debug": "~2.6.9",
@@ -17,6 +18,7 @@
         "express": "~4.16.1",
         "http-errors": "~1.6.3",
         "jade": "~1.11.0",
+        "moment": "^2.30.1",
         "morgan": "~1.9.1"
       },
       "devDependencies": {
@@ -222,6 +224,18 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
+    },
+    "node_modules/array-shuffle": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/array-shuffle/-/array-shuffle-3.0.0.tgz",
+      "integrity": "sha512-rogEGxHOQPhslOhpg12LJkB+bbAl484/s2AJq0BxtzQDQfKl76fS2u9zWgg3p3b9ENcuvE7K8A7l5ddiPjCRnw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/asap": {
       "version": "1.0.0",
@@ -1246,6 +1260,15 @@
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/morgan": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@fal-ai/client": "^1.6.1",
     "@supabase/supabase-js": "^2.53.0",
+    "array-shuffle": "^3.0.0",
     "axios": "^1.11.0",
     "cookie-parser": "~1.4.4",
     "debug": "~2.6.9",
@@ -16,6 +17,7 @@
     "express": "~4.16.1",
     "http-errors": "~1.6.3",
     "jade": "~1.11.0",
+    "moment": "^2.30.1",
     "morgan": "~1.9.1"
   },
   "devDependencies": {

--- a/src/controllers/quizController.js
+++ b/src/controllers/quizController.js
@@ -1,8 +1,9 @@
 import axios from 'axios'; //pentru ollama
 import quizTypes from '../quizTypes.js';
 import { storeQuiz } from '../services/dbServices.js';
+import { generateQuiz } from '../services/quizServices.js';
 
-const ACCEPTED_QUIZ_TYPES = ['historical', 'icebreaker', 'movie_quote'];
+const ACCEPTED_QUIZ_TYPES = Object.keys(quizTypes);
 
 export class QuizController {
   static async handleQuizRequest(req, res) {
@@ -29,9 +30,10 @@ export class QuizController {
       const ollamaResponse = await axios.post(
         'http://ollama.vsp.dev/api/generate',
         {
-          model: 'llama3.1:latest',
+          model: 'magistral:latest',
           prompt: prompt,
-          stream: true
+          stream: true,
+          think: false
         },
         {
           responseType: 'stream',

--- a/src/quizTypes.js
+++ b/src/quizTypes.js
@@ -1,49 +1,85 @@
 const quizTypes = {
   historical: {
-    prompt: `Generate a historical quiz question for the current date, given {{currentDate}}. 
+    prompt: `Create a historical quiz question for a workplace Slack bot. Use the current date ({{currentDate}}). 
     The quiz should be in the following format:
+    \`\`\`
     { 
       "quizText": "...",
       "options": ["...", "...", "...", "..."],
       "answer": "..."
     }
+    \`\`\`
+    GUIDELINES:
+    - Fact-check the events to ensure accuracy.
     - Only include events that are significant and well-known.
     - Ensure the options are plausible and related to the question.
     - The answer must be one of the options provided.
     - The correct answer must be an event that strictly corresponds to the date.
-    - Fact-check the events to ensure accuracy.
     - Respect the JSON format strictly. Do not include any additional text or explanations.
     - An example for an option is "[SHORT EVENT DESCRIPTION], [YEAR]". Follow this format for all options.`,
   },
 
   icebreaker: {
-    prompt: `Create a light-hearted multiple choice icebreaker question for a workplace Slack bot. It should be fun, like 'Never have I ever' or 'Who is most likely to...'. Format the response as: { "quizText": "...", "options": ["...", "...", "...", "..."], "correctAnswer": "..." }`,
+    prompt: `Create a light-hearted multiple choice icebreaker question for a workplace Slack bot. 
+    It should be fun, like 'Never have I ever' or 'Who is most likely to...'. 
+    Your response must be in the following format: 
+    \`\`\`
+    { 
+    "quizText": "...", 
+    "options": ["...", "...", "...", "..."], 
+    "correctAnswer": "..." 
+    }
+    \`\`\`
+    GUIDELINES:
+    - The question should be engaging and suitable for a workplace environment.
+    - The options should be humorous or relatable.
+    - The correct answer should be one of the options provided.
+    - Respect the JSON format strictly. Do not include any additional text or explanations.`,
   },
 
   movie_quote: {
-    prompt: `
-Create a movie quote quiz question in strict JSON format. Structure it like this:
+    prompt: `Create a movie quote quiz question for a workplace Slack bot. Ensure the movie the quote is from is well-known.
+    Your response must be in the following format:
+    \`\`\`
+    {
+      "quizText": "Who said the following quote, and in what movie? \\"You're gonna need a bigger boat\\"",
+      "options": [
+        "Roy Scheider in Jaws",
+        "Harrison Ford in Star Wars",
+        "Tom Hanks in Cast Away",
+        "Robert Shaw in Jaws"
+      ],
+      "answer": "Robert Shaw in Jaws"
+    }
+    \`\`\`
+     GUIDELINES:
+    - Only respond with a **single JSON object** (no extra text, no explanation).
+    - Keys must be: "quizText", "options", "answer"
+    - Use **double quotes** for all strings.
+    - Escape any internal quotes correctly.
+    - Do NOT include headings like "Quote:", "Options:", "Correct answer:", only the JSON.
+    - The quiz should focus on famous quotes and correct attribution (actor + movie).
+    `
+  },
 
-{
-  "quizText": "Who said the following quote, and in what movie? \\"You're gonna need a bigger boat\\"",
-  "options": [
-    "Roy Scheider in Jaws",
-    "Harrison Ford in Star Wars",
-    "Tom Hanks in Cast Away",
-    "Robert Shaw in Jaws"
-  ],
-  "answer": "Robert Shaw in Jaws"
-}
-
- Important:
-- Only respond with a **single JSON object** (no extra text, no explanation).
-- Keys must be: "quizText", "options", "answer"
-- Use **double quotes** for all strings.
-- Escape any internal quotes correctly.
-- Do NOT include headings like "Quote:", "Options:", "Correct answer:" — only the JSON.
-- The quiz should focus on famous quotes and correct attribution (actor + movie).
-`
-  }
+  emoji_riddle: {
+    prompt: `Create an emoji riddle quiz question.
+    Give a combination of emojis that represent a funny well-known concept, object, or phrase.
+    Your response must be in the following format:
+    \`\`\`
+    { 
+      "quizText": "What do these emojis represent? 🔎🐟", 
+      "options": ["Finding Nemo", "Dory", "Glass Fish", "Fish Tank"], 
+      "correctAnswer": "Finding Nemo" 
+    }
+    \`\`\`
+    GUIDELINES:
+    - It should be a fun and engaging riddle.
+    - The question should be clear and concise, and should contain about 3-5 emojis.
+    - The options should be plausible and related to the emoji.
+    - The correct answer should be one of the options provided.
+    - Respect the JSON format strictly. Do not include any additional text or explanations.`,
+  },
 
 
 };

--- a/src/services/quizServices.js
+++ b/src/services/quizServices.js
@@ -1,0 +1,219 @@
+import quizTypes from '../quizTypes.js';
+import axios from 'axios';
+import moment from 'moment';
+
+export async function generateQuiz(type) {
+  // get the prompt from the type
+  let prompt = quizTypes[type].prompt;
+
+  // if the type is 'historical',
+  // replace the {{currentDate}} placeholder with the current date
+  if (type === 'historical') {
+    const quiz = await getHistoricalQuiz('wikimedia', 4);
+    if (!quiz) {
+      if (process.env.NODE_ENV === 'dev') {
+        console.error('Failed to generate historical quiz.');
+      }
+
+      // return null to signify that the quiz could not be generated
+      return null;
+    }
+    return {
+      quizText: quiz.quizText,
+      options: quiz.options,
+      answer: quiz.answer
+    };
+  }
+
+  let validResponse = false;
+  let requestsMade = 0;
+  const maxRequests = 5; // limit the number of requests to avoid infinite loop
+  let quizJson = {};
+
+  while (!validResponse && requestsMade < maxRequests) {
+    // make request to the Ollama server
+    let response;
+
+    try {
+      response = await axios.post(
+        'http://ollama.vsp.dev/api/generate',
+        {
+          model: 'magistral:latest',
+          prompt: prompt,
+          stream: false,
+          think: false
+        },
+        {
+          headers: {
+            Authorization: `Bearer ${process.env.OLLAMA_API_KEY}`
+          }
+        }
+      );
+    } catch (error) {
+      // increment either way
+      requestsMade++;
+
+      if (process.env.NODE_ENV === 'dev') {
+        console.error('Error making request to Ollama:', error.message);
+      }
+      // in case of error, make another request
+      continue;
+
+      // TODO: if requestsMade exceeds maxRequests, exit the loop and throw error
+    }
+
+    const responseQuiz = response.data.response;
+    requestsMade++;
+
+    if (process.env.NODE_ENV === 'dev') console.log('Ollama quiz: ', responseQuiz);
+
+    // parse the quiz from the response
+    quizJson = parseQuiz(responseQuiz);
+
+    if (!quizJson) {
+      if (process.env.NODE_ENV === 'dev') {
+        console.error('Failed to parse quiz from response:', responseQuiz);
+      }
+      // in case of error, make another request
+      continue;
+    }
+
+    if (process.env.NODE_ENV === 'dev') console.log('Parsed quiz successfully: ', quizJson);
+
+    validResponse = true;
+  } // end of while loop
+
+  if (requestsMade >= maxRequests) {
+    if (process.env.NODE_ENV === 'dev') {
+      console.error('Unable to generate a valid quiz after multiple attempts.');
+    }
+
+    // return null to signify that the quiz could not be generated
+    return null;
+  }
+
+  // otherwise, the quiz is valid
+  // return the parsed quiz
+  return {
+    quizText: quizJson.quizText,
+    options: quizJson.options,
+    answer: quizJson.answer
+  };
+}
+
+function parseQuiz(responseQuiz) {
+  // replace literal newlines with \n
+  responseQuiz = responseQuiz.replace(/"((?:[^"\\]|\\.)*)"/gs, (m, group) =>
+    `"${group.replace(/\r?\n/g, '\\n')}"`
+  );
+
+  const match = responseQuiz.match(
+    /\{\s*"quizText"\s*:\s*".+?",\s*"options"\s*:\s*\[.*?\],\s*"(answer|correctAnswer)"\s*:\s*".*?"\s*\}/s
+  );
+
+  if (!match) {
+    if (process.env.NODE_ENV === 'dev') console.error('Unable to find RegEx match.');
+
+    // return null to signify that the quiz could not be parsed
+    return null;
+  }
+
+  const quizJson = JSON.parse(match[0]);
+
+  // fix naming of the answer field
+  //  sometimes the LLM returns "answer" and sometimes "correctAnswer"
+  if (quizJson.correctAnswer && !quizJson.answer) {
+    quizJson.answer = quizJson.correctAnswer;
+
+    // delete the correctAnswer field from quizJson object
+    delete quizJson.correctAnswer;
+  }
+
+  return quizJson;
+}
+
+async function getHistoricalQuiz(provider, numberOfOptions) {
+
+  const currentDate = new Date();
+  const dates = [currentDate]
+  const options = []
+
+  for (let i = 0; i < numberOfOptions - 1; i++) {
+    const randomDate = getRandomDate();
+
+    // check if the random date is the same as the current date
+    if (randomDate === currentDate) {
+      i--; // try current iteration again
+      continue; // skip this iteration
+    }
+
+    // add to dates array
+    dates.push(getRandomDate());
+  }
+
+  switch (provider) {
+    case 'wikimedia':
+      for (const date of dates) {
+        const event = await getWikimediaEvent(date);
+
+        // TODO: better handling in case of random date (or current date)
+        //  not having an event
+        if (event) {
+          options.push(event);
+        }
+      }
+      break;
+    case 'zenquotes':
+      break;
+    default:
+      throw new Error(`Unknown provider: ${provider}`);
+  }
+
+  // now that all the options are fetched
+  // save the first option as the correct answer
+  const correctAnswer = options[0];
+
+  // and now shuffle the options
+  options.sort(() => Math.random() - 0.5);
+
+  return {
+    quizText: `What happened today, ${moment().format('MMMM Qo')}, in history?`,
+    options: options,
+    answer: options.find(option => option === correctAnswer)
+  }
+}
+
+function getRandomDate() {
+  const start = new Date(2000, 0, 1); // January 1, 2000
+  const end = new Date(); // Current date
+  const randomDate = new Date(start.getTime() + Math.random() * (end.getTime() - start.getTime()));
+  return randomDate;
+}
+
+async function getWikimediaEvent(date) {
+  const paddedMonth = String(date.getMonth() + 1).padStart(2, '0');
+  const paddedDay = String(date.getDate()).padStart(2, '0');
+
+  try {
+    const response = await axios.get(
+      `https://api.wikimedia.org/feed/v1/wikipedia/en/onthisday/events/${paddedMonth}/${paddedDay}`,
+    );
+
+    const events = response.data.events;
+
+    if (!events || events.length === 0) {
+      throw new Error(`No events found for the given date (${date.toDateString()}).`);
+    }
+
+    // select a random event
+    const randomEvent = events[Math.floor(Math.random() * events.length)].text;
+
+    return randomEvent;
+
+  } catch (error) {
+    if (process.env.NODE_ENV === 'dev') {
+      console.error('Error fetching data from Wikimedia API:', error.message);
+    }
+    return null; // Return null in case of error
+  }
+}


### PR DESCRIPTION
- Pentru generarea quiz-urilor acum se foloseste modelul de Magistral
- Schimbat un pic prompt-urile cu guideline-uri suplimentare
- Adaugat `emoji_riddle` quiz type
- Adaugat metoda `generateQuiz()` in `quizServices` ca sa avem logica de generare acolo, separata de controller (**deocamdata nu o folositi, lasam la sfarsit refactoring si clean code-ul**)
- Adaugat generarea de historical quiz cu API call catre Wikimedia (**deocamdata nu o folositi, lasam cu LLM  prompt asa cum era**).