### PR TITLE
Update `GET /quiz` route method to also return a URL to an image matching quiz type

### DIFF
--- a/src/controllers/quizController.js
+++ b/src/controllers/quizController.js
@@ -1,6 +1,7 @@
 import axios from 'axios'; //pentru ollama
 import quizTypes from '../quizTypes.js';
 import { getActiveQuiz, storeQuiz } from '../services/dbServices.js';
+import { generateQuizImage } from '../services/imageGenerationServices.js';
 
 const ACCEPTED_QUIZ_TYPES = Object.keys(quizTypes);
 
@@ -87,13 +88,19 @@ export class QuizController {
           delete quiz.correctAnswer;
         }
 
+        // generate quiz image
+        const quizImageUrl = await generateQuizImage({
+          imagePrompt: quizTypes[type].image_prompt
+        })
+
         const quizId = await storeQuiz({ type, quiz, duration });
 
         return res.json({
           quiz_id: quizId,
           quizText: quiz.quizText,
           options: quiz.options,
-          answer: quiz.answer
+          answer: quiz.answer,
+          imageUrl: quizImageUrl
         });
       });
 

--- a/src/quizTypes.js
+++ b/src/quizTypes.js
@@ -17,6 +17,7 @@ const quizTypes = {
     - The correct answer must be an event that strictly corresponds to the date.
     - Respect the JSON format strictly. Do not include any additional text or explanations.
     - An example for an option is "[SHORT EVENT DESCRIPTION], [YEAR]". Follow this format for all options.`,
+    image_prompt: `Cartoon-style collage with thick strokes, showcasing pop culture through the decades. Include colorful illustrations of iconic items and styles: a vinyl record, cassette tape, boombox, Rubik’s cube, floppy disk, flip phone, early MP3 player, disco ball, VHS tape, lava lamp, retro video game console, and fashion styles like platform shoes, neon windbreakers, and skinny jeans. Bright, nostalgic, and playful atmosphere. No real people or logos or text, just symbolic objects representing the eras.`
   },
 
   icebreaker: {
@@ -35,6 +36,7 @@ const quizTypes = {
     - The options should be humorous or relatable.
     - The correct answer should be one of the options provided.
     - Respect the JSON format strictly. Do not include any additional text or explanations.`,
+    image_prompt: `Cartoon-style image with thick strokes showing a playful icebreaker game in progress: a spinning bottle surrounded by colorful question cards, a whiteboard with doodles like 'Who is more likely to...', party snacks on a table, and balloons tied to office chairs. No people or faces. Vivid, energetic, with an easy-going and humorous tone.`
   },
 
   movie_quote: {
@@ -59,7 +61,8 @@ const quizTypes = {
     - Escape any internal quotes correctly.
     - Do NOT include headings like "Quote:", "Options:", "Correct answer:", only the JSON.
     - The quiz should focus on famous quotes and correct attribution (actor + movie).
-    `
+    `,
+    image_prompt: `Cartoon-style collage with thick strokes featuring iconic movie and TV elements: popcorn bucket, classic cinema clapperboard, retro TV set, film reels. Include silhouette-style or generic representations of globally recognized movie/TV characters (e.g., wizard with glasses, sci-fi soldier, superhero cape), avoiding direct likeness to copyrighted characters. Use bright, cinematic colors—reds, yellows, dark blues—and add sparkles or light flares to evoke a theater atmosphere.`
   },
 
   emoji_riddle: {
@@ -79,6 +82,7 @@ const quizTypes = {
     - The options should be plausible and related to the emoji.
     - The correct answer should be one of the options provided.
     - Respect the JSON format strictly. Do not include any additional text or explanations.`,
+    image_prompt: `Cartoon-style illustration with thick strokes featuring a colorful cluster of oversized emojis arranged like a puzzle or riddle. Include classic emojis like the thinking face 🤔, magnifying glass 🔍, sunglasses 😎, rocket 🚀, heart ❤️, pizza 🍕, etc., floating around or stacked playfully. Place a cartoon speech bubble with a question mark inside or a chalkboard with emojis written on it. Bright, fun, and slightly mysterious to evoke the idea of solving an emoji puzzle. No humans or animals.`
   },
 
 

--- a/src/services/imageGenerationServices.js
+++ b/src/services/imageGenerationServices.js
@@ -8,22 +8,18 @@ fal.config({
 });
 
 
-const GENERATION_PROMPT = `Using the provided picture of a profile picture of a human,
+const REWARD_IMAGE_GENERATION_PROMPT = `Using the provided picture of a profile picture of a human,
 generate an image of the human as a king sitting on a throne.
 If the image is not a human, create a poster image with the text: {{DISPLAY_NAME}}. 
 `;
 
 export const generateRewardImage = async ({ imageUrl, userDisplayName }) => {
   try {
-    // console.log("Apelez fal.subscribe cu:");
-    // console.log("➡️ imageUrl:", imageUrl);
-    // console.log("➡️ userDisplayName:", userDisplayName);
-
     const result = await fal.subscribe(
       'fal-ai/flux-kontext/dev',
       {
         input: {
-          prompt: GENERATION_PROMPT.replace('{{DISPLAY_NAME}}', userDisplayName),
+          prompt: REWARD_IMAGE_GENERATION_PROMPT.replace('{{DISPLAY_NAME}}', userDisplayName),
           image_url: imageUrl
         },
         logs: true,
@@ -38,11 +34,39 @@ export const generateRewardImage = async ({ imageUrl, userDisplayName }) => {
     // return generated image URL
     //console.log("URL imagine generată:", result.data.images[0].url);
     return result.data.images[0].url;
-    
+
 
 
   } catch (error) {
-    console.error('Error generating image:', error);
-    throw new Error('Failed to generate image');
+    console.error('Error generating reward image:', error);
+    throw new Error('Failed to generate reward image');
   }
 };
+
+export async function generateQuizImage({imagePrompt}) {
+  try {
+    const result = await fal.subscribe(
+      "fal-ai/flux-1/schnell",
+      {
+        input: {
+          num_inference_steps: 6, // default is 4
+          prompt: imagePrompt,
+          image_size: "square",
+        },
+        logs: true,
+        onQueueUpdate: (update) => {
+          if (update.status === "IN_PROGRESS") {
+            update.logs.map((log) => log.message).forEach(console.log);
+          }
+        }
+      }
+    );
+
+    // return generated image URL
+    return result.data.images[0].url;
+
+  } catch (error) {
+    console.error('Error generating quiz image:', error);
+    throw new Error('Failed to generate quiz image');
+  }
+}


### PR DESCRIPTION
Update `GET /quiz` route method to also return a URL to an image matching quiz type

Additionally:
- Added a method `generateQuizImage()` that makes the request for the image generation, using only the quiz type
- Updated `quizTypes` to also include a prompt used to create an image that matches with the respective quiz type.